### PR TITLE
Fix export_mappings, return XML files instead of closed zip files

### DIFF
--- a/src/airlock_gateway_rest_api_lib/airlock_gateway_rest_api_lib.py
+++ b/src/airlock_gateway_rest_api_lib/airlock_gateway_rest_api_lib.py
@@ -569,7 +569,7 @@ def export_mappings(gw_session: GatewaySession,
         if res.status_code == 200:
             with ZipFile(BytesIO(res.content)) as zip_file:
                 with zip_file.open("alec_table.xml", "r") as mapping_xml:
-                    mapping_xmls.append(mapping_xml)
+                    mapping_xmls.append(mapping_xml.read())
         else:
             logging.info("Mapping with ID %s was not found on Airlock Host",
                          mapping_id)


### PR DESCRIPTION
Dear Airlock Team

Currently the function `export_mappings` returns a list of closed ZIP files. The `read()` call was missing to actually append the XML files to the list.

Thank you for creating the Python API!