### PR TITLE
ALDENY-444 [8.6: Bugfix] Fix type in denyrules call

### DIFF
--- a/src/rest_api_lib/denyrules.py
+++ b/src/rest_api_lib/denyrules.py
@@ -164,7 +164,7 @@ def update_mapping_custom_deny_rule(gw_session: al.GatewaySession, mapping_id: s
     path = f'/configuration/mappings/{mapping_id}/custom-deny-rules/{custom_denyrule_id}'
     data = {
         "data": {
-            "type": "mapping-deny-rule",
+            "type": "mapping-custom-deny-rule",
             "id": custom_denyrule_id,
             "attributes": attributes
         }


### PR DESCRIPTION
Der GW gibt leider trotzdem Status Code 200 zurück, aber ändert nichts. Gut wäre ein Check, dass der type mit der URL übereinstimmt.